### PR TITLE
Adapt for axum 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/imbolc/axum-client-ip"
 version = "0.1.0"
 
 [dependencies]
-axum = "0.4"
+axum = "0.5"
 forwarded-header-value = "0.1"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ async fn main() {
     axum::Server::bind(&"0.0.0.0:3000".parse().unwrap())
         .serve(
             // Don't forget to add `ConnetInfo` if you aren't behind a proxy
-            app.into_make_service_with_connect_info::<SocketAddr, _>()
+            app.into_make_service_with_connect_info::<SocketAddr>()
         )
         .await
         .unwrap()


### PR DESCRIPTION
This adapts `axum-client-ip` to support axum v0.5 ([changelog](https://tokio.rs/blog/2022-03-whats-new-in-axum-0-5)).

Let me know if I should change anything! :) 