### PR TITLE
doc: when FlyClientIP is run on health check path provide header

### DIFF
--- a/src/rudimental.rs
+++ b/src/rudimental.rs
@@ -47,6 +47,11 @@ pub struct XRealIp(pub IpAddr);
 
 /// Extracts a valid IP from `Fly-Client-IP` (Fly.io) header
 ///
+/// When [FlyClientIp] extractor is run for health check path,
+/// provide required `Fly-Client-IP` header through
+/// [`services.http_checks.headers`](https://fly.io/docs/reference/configuration/#services-http_checks)
+/// or [`http_service.checks.headers`](https://fly.io/docs/reference/configuration/#services-http_checks)
+///
 /// Rejects with a 500 error if the header is absent or the IP isn't valid
 #[derive(Debug)]
 pub struct FlyClientIp(pub IpAddr);


### PR DESCRIPTION
resolves #15 

Screenshot of rendered doc for changes in this PR:

![Screenshot from 2023-08-15 00-46-28](https://github.com/imbolc/axum-client-ip/assets/4025962/fa68ea96-29f6-4d2e-9845-9648fe6e6995)
