### PR TITLE
Disable unused axum features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/imbolc/axum-client-ip"
 version = "0.4.2"
 
 [dependencies]
-axum = "0.6"
+axum = { version = "0.6", default-features = false, features = ["http1", "tokio"] }
 forwarded-header-value = "0.1"
 serde = { version = "1", features = ["derive"] }
 


### PR DESCRIPTION
This disables the enabled-by-default features of axum that we don't actually need:

* form
* json
* matched-path
* original-uri
* query
* tower-log