### PR TITLE
feat: Support obtaining client IP from CloudFront-Viewer-Address header

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,3 @@ rusty-hook = "0.11"
 tokio = { version = "1", features = ["full"] }
 tower = "0.4"
 http-body-util = "0.1"
-
-[features]
-aws-cloudfront = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ rusty-hook = "0.11"
 tokio = { version = "1", features = ["full"] }
 tower = "0.4"
 http-body-util = "0.1"
+
+[features]
+aws-cloudfront = []

--- a/src/insecure.rs
+++ b/src/insecure.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "aws-cloudfront")]
+use crate::rudimental::CloudFrontViewerAddress;
 use crate::rudimental::{
     CfConnectingIp, FlyClientIp, Forwarded, MultiIpHeader, SingleIpHeader, TrueClientIp,
     XForwardedFor, XRealIp,
@@ -43,12 +45,17 @@ impl InsecureClientIp {
         headers: &HeaderMap<HeaderValue>,
         extensions: &Extensions,
     ) -> Result<Self, Rejection> {
-        XForwardedFor::maybe_leftmost_ip(headers)
+        let maybe_ip = XForwardedFor::maybe_leftmost_ip(headers)
             .or_else(|| Forwarded::maybe_leftmost_ip(headers))
             .or_else(|| XRealIp::maybe_ip_from_headers(headers))
             .or_else(|| FlyClientIp::maybe_ip_from_headers(headers))
             .or_else(|| TrueClientIp::maybe_ip_from_headers(headers))
-            .or_else(|| CfConnectingIp::maybe_ip_from_headers(headers))
+            .or_else(|| CfConnectingIp::maybe_ip_from_headers(headers));
+
+        #[cfg(feature = "aws-cloudfront")]
+        let maybe_ip = maybe_ip.or_else(|| CloudFrontViewerAddress::maybe_ip_from_headers(headers));
+
+        maybe_ip
             .or_else(|| maybe_connect_info(extensions))
             .map(Self)
             .ok_or((

--- a/src/rudimental.rs
+++ b/src/rudimental.rs
@@ -71,7 +71,6 @@ pub struct CfConnectingIp(pub IpAddr);
 /// Extracts a valid IP from `CloudFront-Viewer-Address` (AWS CloudFront) header
 ///
 /// Rejects with a 500 error if the header is absent or the IP isn't valid
-#[cfg(feature = "aws-cloudfront")]
 #[derive(Debug)]
 pub struct CloudFrontViewerAddress(pub IpAddr);
 
@@ -169,7 +168,6 @@ impl_single_header!(FlyClientIp, "Fly-Client-IP");
 impl_single_header!(TrueClientIp, "True-Client-IP");
 impl_single_header!(CfConnectingIp, "CF-Connecting-IP");
 
-#[cfg(feature = "aws-cloudfront")]
 impl SingleIpHeader for CloudFrontViewerAddress {
     const HEADER: &'static str = "cloudfront-viewer-address";
 
@@ -188,7 +186,6 @@ impl SingleIpHeader for CloudFrontViewerAddress {
     }
 }
 
-#[cfg(feature = "aws-cloudfront")]
 #[async_trait]
 impl<S> FromRequestParts<S> for CloudFrontViewerAddress
 where
@@ -574,7 +571,6 @@ mod tests {
         assert_eq!(body_string(res.into_body()).await, "192.0.2.60");
     }
 
-    #[cfg(feature = "aws-cloudfront")]
     #[tokio::test]
     async fn cloudfront_viewer_address_ipv4() {
         fn app() -> Router {
@@ -597,7 +593,6 @@ mod tests {
         assert_eq!(body_string(res.into_body()).await, "198.51.100.10");
     }
 
-    #[cfg(feature = "aws-cloudfront")]
     #[tokio::test]
     async fn cloudfront_viewer_address_ipv6() {
         fn app() -> Router {

--- a/src/secure.rs
+++ b/src/secure.rs
@@ -1,8 +1,6 @@
-#[cfg(feature = "aws-cloudfront")]
-use crate::rudimental::CloudFrontViewerAddress;
 use crate::rudimental::{
-    CfConnectingIp, FlyClientIp, Forwarded, MultiIpHeader, SingleIpHeader, StringRejection,
-    TrueClientIp, XForwardedFor, XRealIp,
+    CfConnectingIp, CloudFrontViewerAddress, FlyClientIp, Forwarded, MultiIpHeader, SingleIpHeader,
+    StringRejection, TrueClientIp, XForwardedFor, XRealIp,
 };
 use axum::async_trait;
 use axum::extract::{ConnectInfo, Extension, FromRequestParts};
@@ -47,7 +45,6 @@ pub enum SecureClientIpSource {
     /// IP from the [`axum::extract::ConnectInfo`]
     ConnectInfo,
     /// IP from the `CloudFront-Viewer-Address` header
-    #[cfg(feature = "aws-cloudfront")]
     CloudFrontViewerAddress,
 }
 
@@ -82,7 +79,6 @@ impl FromStr for SecureClientIpSource {
             "TrueClientIp" => Self::TrueClientIp,
             "CfConnectingIp" => Self::CfConnectingIp,
             "ConnectInfo" => Self::ConnectInfo,
-            #[cfg(feature = "aws-cloudfront")]
             "CloudFrontViewerAddress" => Self::CloudFrontViewerAddress,
             _ => return Err(ParseSecureClientIpSourceError(s.to_string())),
         })
@@ -107,7 +103,6 @@ impl SecureClientIp {
             SecureClientIpSource::FlyClientIp => FlyClientIp::ip_from_headers(headers),
             SecureClientIpSource::TrueClientIp => TrueClientIp::ip_from_headers(headers),
             SecureClientIpSource::CfConnectingIp => CfConnectingIp::ip_from_headers(headers),
-            #[cfg(feature = "aws-cloudfront")]
             SecureClientIpSource::CloudFrontViewerAddress => {
                 CloudFrontViewerAddress::ip_from_headers(headers)
             }


### PR DESCRIPTION
Hi! Thanks for the crate! 

This PR adds support for the `CloudFront-Viewer-Address` header supported by AWS CloudFront. 

I put the feature behind a feature flag, since it could hardly be called a standard, but this could also be omitted if you prefer the simpler version without the feature flag. 

Thanks! 
