### PR TITLE
Display imp for ClientIpSource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.todo.md
 /target
 Cargo.lock
+.idea/


### PR DESCRIPTION
Adds a Display impl for ClientIpSource, and a unit test to ensure that `Display` == `FromStr`.

Currently the test has to have the variants manually listed. I appreciate this is not ideal since new variants can be added to the enum and the test would still pass. Best alternative I can think of is to create a proc-macro which generates the test, something I didn't want to do without at least talking to you first.

My usecase should you be interested is declaring a default value for an arg with clap.
```rust
#[derive(Parser, Debug)]
pub(crate) struct Foo {
    #[arg(long, default_value_t = ClientIpSource::ConnectInfo)] // <------
    pub(crate) client_ip_source: ClientIpSource,
}
```
For some reason they appear to be using the `ToString` trait and then comparing the result of that rather than using `FromStr`.

Appreciate your work on this crate!