### PR TITLE
feat: make tokio optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,16 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["serde"]
+default = ["serde", "connect-info"]
+# Enables `ConnectInfo` extractor
+connect-info = ["axum/tokio"]
 # Enables `RightmostForwarded` extractor
 forwarded-header = ["client-ip/forwarded-header"]
 # Enables `ClientIpSource` serde compatibility
 serde = ["dep:serde"]
 
 [dependencies]
-axum = { version = "0.8", default-features = false, features = ["tokio"] }
+axum = { version = "0.8", default-features = false }
 client-ip = "0.1"
 serde = { version = "1", features = ["derive"], optional = true }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,15 +4,21 @@ use std::{
     error::Error,
     fmt,
     marker::Sync,
-    net::{IpAddr, SocketAddr},
+    net::IpAddr,
     str::FromStr,
 };
 
 use axum::{
-    extract::{ConnectInfo, Extension, FromRequestParts},
+    extract::{Extension, FromRequestParts},
     http::{StatusCode, request::Parts},
     response::{IntoResponse, Response},
 };
+
+#[cfg(feature = "connect-info")]
+use std::net::SocketAddr;
+
+#[cfg(feature = "connect-info")]
+use axum::extract::ConnectInfo;
 
 /// Defines an extractor
 macro_rules! define_extractor {
@@ -116,6 +122,7 @@ pub enum ClientIpSource {
     CfConnectingIp,
     /// IP from the `CloudFront-Viewer-Address` header
     CloudFrontViewerAddress,
+    #[cfg(feature = "connect-info")]
     /// IP from the [`axum::extract::ConnectInfo`]
     ConnectInfo,
     /// IP from the `Fly-Client-IP` header
@@ -158,6 +165,7 @@ impl FromStr for ClientIpSource {
         Ok(match s {
             "CfConnectingIp" => Self::CfConnectingIp,
             "CloudFrontViewerAddress" => Self::CloudFrontViewerAddress,
+            #[cfg(feature = "connect-info")]
             "ConnectInfo" => Self::ConnectInfo,
             "FlyClientIp" => Self::FlyClientIp,
             #[cfg(feature = "forwarded-header")]
@@ -176,6 +184,7 @@ impl fmt::Display for ClientIpSource {
         f.write_str(match self {
             ClientIpSource::CfConnectingIp => "CfConnectingIp",
             ClientIpSource::CloudFrontViewerAddress => "CloudFrontViewerAddress",
+            #[cfg(feature = "connect-info")]
             ClientIpSource::ConnectInfo => "ConnectInfo",
             ClientIpSource::FlyClientIp => "FlyClientIp",
             #[cfg(feature = "forwarded-header")]
@@ -203,6 +212,7 @@ where
             ClientIpSource::CloudFrontViewerAddress => {
                 CloudFrontViewerAddress::ip_from_headers(&parts.headers)
             }
+            #[cfg(feature = "connect-info")]
             ClientIpSource::ConnectInfo => parts
                 .extensions
                 .get::<ConnectInfo<SocketAddr>>()
@@ -227,6 +237,7 @@ where
 #[non_exhaustive]
 #[derive(Debug, PartialEq)]
 pub enum Rejection {
+    #[cfg(feature = "connect-info")]
     /// No [`axum::extract::ConnectInfo`] in extensions
     NoConnectInfo,
     /// No [`ClientIpSource`] in extensions
@@ -244,6 +255,7 @@ impl From<client_ip::Error> for Rejection {
 impl fmt::Display for Rejection {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            #[cfg(feature = "connect-info")]
             Rejection::NoConnectInfo => {
                 write!(f, "Add `axum::extract::ConnectInfo` to request extensions")
             }
@@ -261,7 +273,9 @@ impl std::error::Error for Rejection {}
 impl IntoResponse for Rejection {
     fn into_response(self) -> Response {
         let title = match self {
-            Self::NoConnectInfo | Self::NoClientIpSource => "500 Axum Misconfiguration",
+            #[cfg(feature = "connect-info")]
+            Self::NoConnectInfo => "500 Axum Misconfiguration",
+            Self::NoClientIpSource => "500 Axum Misconfiguration",
             Self::ClientIp { .. } => "500 Proxy Server Misconfiguration",
         };
         let footer = "(the request is rejected by axum-client-ip)";
@@ -526,6 +540,7 @@ mod tests {
 
         assert_match(ClientIpSource::CfConnectingIp);
         assert_match(ClientIpSource::CloudFrontViewerAddress);
+        #[cfg(feature = "connect-info")]
         assert_match(ClientIpSource::ConnectInfo);
         assert_match(ClientIpSource::FlyClientIp);
         #[cfg(feature = "forwarded-header")]


### PR DESCRIPTION
I use axum with [workers-rs](https://github.com/cloudflare/workers-rs), but tokio isn't supported on Cloudflare workers.

This PR makes tokio optional: it introduces a connect-info feature flag (enabled by default for backward compatibility).